### PR TITLE
added 'nosync' functionality

### DIFF
--- a/9volt-cfg/example-configs/example1.yaml
+++ b/9volt-cfg/example-configs/example1.yaml
@@ -74,22 +74,22 @@ monitor:
       - secondary-slack
       - primary-pagerduty
 
-  basic-http-check:
-    type: http
-    description: "basic http status code check"
-    host: cloudsy.com
-    timeout: 5s
-    interval: 10s
-    enabled: true
-    port: 80
-    status-code: 200
-    tags:
-      - team-core
-      - golang
-    warning-threshold: 1
-    critical-threshold: 3
-    warning-alerter:
-      - primary-slack
-    critical-alerter:
-      - primary-slack
-      - primary-pagerduty
+  # basic-http-check:
+  #   type: http
+  #   description: "basic http status code check"
+  #   host: cloudsy.com
+  #   timeout: 5s
+  #   interval: 10s
+  #   enabled: true
+  #   port: 80
+  #   status-code: 200
+  #   tags:
+  #     - team-core
+  #     - golang
+  #   warning-threshold: 1
+  #   critical-threshold: 3
+  #   warning-alerter:
+  #     - primary-slack
+  #   critical-alerter:
+  #     - primary-slack
+  #     - primary-pagerduty


### PR DESCRIPTION
By default, `9volt-cfg` will sync whatever is in its local configs against etcd - ie. it will remove any "orphaned" configs from etcd. Orphaned configs == any config in etcd that does not have a corresponding local config.

This functionality can be disabled by tacking on a `-n || --nosync` flag.