### PR TITLE
swagger comment based api documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+# Some things this makefile could make use of:
+#
+# - test coverage target(s)
+# - profiler target(s)
+#
+
+BIN             = auth-api
+OUTPUT_DIR      = build
+TMP_DIR        := .tmp
+RELEASE_VER    := $(shell git rev-parse --short HEAD)
+DOCKER_IP       = $(shell docker info | grep -q moby && echo localhost || docker-machine ip)
+NAME            = default
+COVERMODE       = atomic
+
+TEST_PACKAGES      := $(shell go list ./... | grep -v vendor | grep -v fakes | grep -v ftest)
+
+.PHONY: help
+.DEFAULT_GOAL := help
+
+run: ## Run application (without building)
+	go run *.go -d -e http://localhost:2379
+
+all: test build docker ## Test, build and docker image build
+
+setup: installtools ## Install and setup tools
+
+test: ## Perform tests
+	go test -cover $(TEST_PACKAGES)
+
+testv: ## Perform tests (with verbose flag)
+	go test -v -cover $(TEST_PACKAGES)
+
+test/race: ## Perform tests and enable the race detector
+	go test -race -cover $(TEST_PACKAGES)
+
+test/cover: ## Run all tests + open coverage report for all packages
+	echo 'mode: $(COVERMODE)' > .coverage
+	for PKG in $(TEST_PACKAGES); do \
+		go test -coverprofile=.coverage.tmp -tags "integration" $$PKG; \
+		grep -v -E '^mode:' .coverage.tmp >> .coverage; \
+	done
+	go tool cover -html=.coverage
+	$(RM) .coverage .coverage.tmp
+
+installtools: ## Install development related tools
+	go get github.com/kardianos/govendor
+	go get github.com/maxbrunsfeld/counterfeiter
+	go get github.com/yvasiyarov/swagger
+
+build: clean build/linux build/darwin ## Build for linux and darwin (save to OUTPUT_DIR/BIN)
+
+build/linux: clean/linux ## Build for linux (save to OUTPUT_DIR/BIN)
+	GOOS=linux go build -a -installsuffix cgo -ldflags "-X main.version=$(RELEASE_VER)" -o $(OUTPUT_DIR)/$(BIN)-linux .
+
+build/darwin: clean/darwin ## Build for darwin (save to OUTPUT_DIR/BIN)
+	GOOS=darwin go build -a -installsuffix cgo -ldflags "-X main.version=$(RELEASE_VER)" -o $(OUTPUT_DIR)/$(BIN)-darwin .
+
+build/docs: ## Build markdown docs from swagger comments
+	swagger -apiPackage="github.com/9corp/9volt" -format=markdown -output=docs/api/README.md
+
+clean: clean/darwin clean/linux ## Remove all build artifacts
+
+clean/darwin: ## Remove darwin build artifacts
+	$(RM) $(OUTPUT_DIR)/$(BIN)-darwin
+
+clean/linux: ## Remove linux build artifacts
+	$(RM) $(OUTPUT_DIR)/$(BIN)-linux
+
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_\/-]+:.*?## / {printf "\033[34m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | \
+		sort | \
+		grep -v '#'

--- a/api/api.go
+++ b/api/api.go
@@ -1,3 +1,13 @@
+// @APIVersion 1.0.0
+// @APITitle 9volt API
+// @APIDescription 9volt's API for fetching check state, event data and cluster information
+// @Contact daniel.selans@gmail.com
+// @License MIT
+// @LicenseUrl https://opensource.org/licenses/MIT
+// @BasePath /api/v1
+// @SubApi Cluster State [/cluster]
+// @SubApi Monitor Configuration [/monitor]
+
 package api
 
 import (

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -8,6 +8,11 @@ import (
 	"github.com/InVisionApp/rye"
 )
 
+// @Title Fetch Cluster Stats
+// @Description Fetches cluster state data (membership, current director, heartbeats)
+// @Success 200 {object} dal.ClusterStats
+// @Failure 500 {object} rye.JSONStatus
+// @Router /cluster [get]
 func (a *Api) ClusterHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
 	clusterStats, err := a.Config.DalClient.GetClusterStats()
 	if err != nil {

--- a/api/event.go
+++ b/api/event.go
@@ -6,8 +6,17 @@ import (
 	"strings"
 
 	"github.com/InVisionApp/rye"
+
+	_ "github.com/9corp/9volt/event" // importing for swagger
 )
 
+// @Title Fetch Events
+// @Description Fetch event data (optionally filtered by one or more event types)
+// @Accept  json
+// @Param   type     query    string     false        "comma separated event types"
+// @Success 200 {array}  event.Event
+// @Failure 500 {object} rye.JSONStatus
+// @Router /event [get]
 func (a *Api) EventHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
 	eventData, err := a.Config.DalClient.FetchEvents([]string{})
 	if err != nil {

--- a/api/monitor.go
+++ b/api/monitor.go
@@ -16,6 +16,13 @@ import (
 
 type fullMonitorConfig map[string]*json.RawMessage
 
+// @Title Fetch Monitor Configuration
+// @Description Fetch all (or specific) monitor configuration(s) from etcd
+// @Accept  json
+// @Param   check     path    string     false        "Specific check name"
+// @Success 200 {array}  fullMonitorConfig
+// @Failure 500 {object} rye.JSONStatus
+// @Router /monitor/{check} [get]
 func (a *Api) MonitorHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
 	data, err := a.Config.DalClient.Get("monitor", &dal.GetOptions{
 		Recurse: true,
@@ -49,6 +56,14 @@ func (a *Api) MonitorHandler(rw http.ResponseWriter, r *http.Request) *rye.Respo
 	return nil
 }
 
+// @Title Set Disabled State for Given Monitor
+// @Description Enable or disable a specific monitor configuration (changes are immediate)
+// @Accept  json
+// @Param   check     path    string     true        "Specific check name"
+// @Param   disable     query    string     false        "Disable/enable a check"
+// @Success 200 {array}  rye.JSONStatus
+// @Failure 500 {object} rye.JSONStatus
+// @Router /monitor/{check} [get]
 func (a *Api) MonitorDisableHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
 	checkName := mux.Vars(r)["check"]
 

--- a/api/state.go
+++ b/api/state.go
@@ -6,8 +6,18 @@ import (
 	"strings"
 
 	"github.com/InVisionApp/rye"
+
+	_ "github.com/9corp/9volt/state"
 )
 
+// @Title Fetch Check State Data
+// @Description Fetch check state data including latest check status, ownership, last check timestamp;
+//              optionally filter the state data by checks that contain one or more tags.
+// @Accept  json
+// @Param   tags     query    string     false        "One or more tags (comma separated)"
+// @Success 200 {array}  state.Message
+// @Failure 500 {object} rye.JSONStatus
+// @Router /state [get]
 func (a *Api) StateHandler(rw http.ResponseWriter, r *http.Request) *rye.Response {
 	stateData, err := a.Config.DalClient.FetchState()
 	if err != nil {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,311 @@
+
+# 
+
+
+Table of Contents
+
+1. [Cluster State](#cluster)
+1. [Fetch event data (optionally filtered by one or more event types)](#event)
+1. [Monitor Configuration](#monitor)
+1. [Fetch check state data including latest check status, ownership, last check timestamp;](#state)
+
+<a name="cluster"></a>
+
+## cluster
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /cluster |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes |  |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /cluster | [GET](#Fetch Cluster Stats) | Fetches cluster state data (membership, current director, heartbeats) |
+
+
+
+<a name="Fetch Cluster Stats"></a>
+
+#### API: /cluster (GET)
+
+
+Fetches cluster state data (membership, current director, heartbeats)
+
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | object | [ClusterStats](#github.com.9corp.9volt.dal.ClusterStats) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="encoding.json.RawMessage"></a>
+
+#### RawMessage
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+
+<a name="github.com.9corp.9volt.dal.ClusterStats"></a>
+
+#### ClusterStats
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| Director | encoding.json.RawMessage |  |
+| Members | array |  |
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+
+<a name="event"></a>
+
+## event
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /event |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes | application/json |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /event | [GET](#Fetch Events) | Fetch event data (optionally filtered by one or more event types) |
+
+
+
+<a name="Fetch Events"></a>
+
+#### API: /event (GET)
+
+
+Fetch event data (optionally filtered by one or more event types)
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| type | query | string | comma separated event types |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [Event](#github.com.9corp.9volt.event.Event) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="github.com.9corp.9volt.event.Event"></a>
+
+#### Event
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| memberid | string |  |
+| message | string |  |
+| timestamp | Time |  |
+| type | string |  |
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+
+<a name="monitor"></a>
+
+## monitor
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /monitor |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes | application/json |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /monitor/\{check\} | [GET](#Fetch Monitor Configuration) | Fetch all (or specific) monitor configuration(s) from etcd |
+| /monitor/\{check\} | [GET](#Set Disabled State for Given Monitor) | Enable or disable a specific monitor configuration (changes are immediate) |
+
+
+
+<a name="Fetch Monitor Configuration"></a>
+
+#### API: /monitor/\{check\} (GET)
+
+
+Fetch all (or specific) monitor configuration(s) from etcd
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| check | path | string | Specific check name |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [fullMonitorConfig](#github.com.9corp.9volt.api.fullMonitorConfig) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+<a name="Set Disabled State for Given Monitor"></a>
+
+#### API: /monitor/\{check\} (GET)
+
+
+Enable or disable a specific monitor configuration (changes are immediate)
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| check | path | string | Specific check name | Yes |
+| disable | query | string | Disable/enable a check |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="github.com.9corp.9volt.api.fullMonitorConfig"></a>
+
+#### fullMonitorConfig
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+
+<a name="state"></a>
+
+## state
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /state |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes | application/json |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /state | [GET](#Fetch Check State Data) | Fetch check state data including latest check status, ownership, last check timestamp; |
+
+
+
+<a name="Fetch Check State Data"></a>
+
+#### API: /state (GET)
+
+
+Fetch check state data including latest check status, ownership, last check timestamp;
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| tags | query | string | One or more tags (comma separated) |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [Message](#github.com.9corp.9volt.state.Message) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="encoding.json.RawMessage"></a>
+
+#### RawMessage
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+
+<a name="github.com.9corp.9volt.state.Message"></a>
+
+#### Message
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| check | string |  |
+| config | encoding.json.RawMessage |  |
+| count | int |  |
+| date | Time |  |
+| message | string |  |
+| owner | string |  |
+| status | string |  |
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+

--- a/docs/api/crap.md
+++ b/docs/api/crap.md
@@ -1,0 +1,311 @@
+
+# 
+
+
+Table of Contents
+
+1. [Fetches cluster state data (membership, current director, heartbeats)](#cluster)
+1. [Fetch event data (optionally filtered by one or more event types)](#event)
+1. [Fetch all (or specific) monitor configuration(s) from etcd](#monitor)
+1. [Fetch check state data including latest check status, ownership, last check timestamp;](#state)
+
+<a name="cluster"></a>
+
+## cluster
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /cluster |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes |  |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /cluster | [GET](#Fetch Cluster Stats) | Fetches cluster state data (membership, current director, heartbeats) |
+
+
+
+<a name="Fetch Cluster Stats"></a>
+
+#### API: /cluster (GET)
+
+
+Fetches cluster state data (membership, current director, heartbeats)
+
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | object | [ClusterStats](#github.com.9corp.9volt.dal.ClusterStats) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="encoding.json.RawMessage"></a>
+
+#### RawMessage
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+
+<a name="github.com.9corp.9volt.dal.ClusterStats"></a>
+
+#### ClusterStats
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| Director | encoding.json.RawMessage |  |
+| Members | array |  |
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+
+<a name="event"></a>
+
+## event
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /event |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes | application/json |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /event | [GET](#Fetch Events) | Fetch event data (optionally filtered by one or more event types) |
+
+
+
+<a name="Fetch Events"></a>
+
+#### API: /event (GET)
+
+
+Fetch event data (optionally filtered by one or more event types)
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| type | query | string | comma separated event types |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [Event](#github.com.9corp.9volt.event.Event) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="github.com.9corp.9volt.event.Event"></a>
+
+#### Event
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| memberid | string |  |
+| message | string |  |
+| timestamp | Time |  |
+| type | string |  |
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+
+<a name="monitor"></a>
+
+## monitor
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /monitor |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes | application/json |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /monitor/\{check\} | [GET](#Fetch Monitor Configuration) | Fetch all (or specific) monitor configuration(s) from etcd |
+| /monitor/\{check\} | [GET](#Set Disabled State for Given Monitor) | Enable or disable a specific monitor configuration (changes are immediate) |
+
+
+
+<a name="Fetch Monitor Configuration"></a>
+
+#### API: /monitor/\{check\} (GET)
+
+
+Fetch all (or specific) monitor configuration(s) from etcd
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| check | path | string | Specific check name |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [fullMonitorConfig](#github.com.9corp.9volt.api.fullMonitorConfig) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+<a name="Set Disabled State for Given Monitor"></a>
+
+#### API: /monitor/\{check\} (GET)
+
+
+Enable or disable a specific monitor configuration (changes are immediate)
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| check | path | string | Specific check name | Yes |
+| disable | query | string | Disable/enable a check |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="github.com.9corp.9volt.api.fullMonitorConfig"></a>
+
+#### fullMonitorConfig
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+
+<a name="state"></a>
+
+## state
+
+| Specification | Value |
+|-----|-----|
+| Resource Path | /state |
+| API Version |  |
+| BasePath for the API | {{.}} |
+| Consumes | application/json |
+| Produces |  |
+
+
+
+### Operations
+
+
+| Resource Path | Operation | Description |
+|-----|-----|-----|
+| /state | [GET](#Fetch Check State Data) | Fetch check state data including latest check status, ownership, last check timestamp; |
+
+
+
+<a name="Fetch Check State Data"></a>
+
+#### API: /state (GET)
+
+
+Fetch check state data including latest check status, ownership, last check timestamp;
+
+
+
+| Param Name | Param Type | Data Type | Description | Required? |
+|-----|-----|-----|-----|-----|
+| tags | query | string | One or more tags (comma separated) |  |
+
+
+| Code | Type | Model | Message |
+|-----|-----|-----|-----|
+| 200 | array | [Message](#github.com.9corp.9volt.state.Message) |  |
+| 500 | object | [JSONStatus](#github.com.InVisionApp.rye.JSONStatus) |  |
+
+
+
+
+### Models
+
+<a name="encoding.json.RawMessage"></a>
+
+#### RawMessage
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+
+<a name="github.com.9corp.9volt.state.Message"></a>
+
+#### Message
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| check | string |  |
+| config | encoding.json.RawMessage |  |
+| count | int |  |
+| date | Time |  |
+| message | string |  |
+| owner | string |  |
+| status | string |  |
+
+<a name="github.com.InVisionApp.rye.JSONStatus"></a>
+
+#### JSONStatus
+
+| Field Name (alphabetical) | Field Type | Description |
+|-----|-----|-----|
+| message | string |  |
+| status | string |  |
+
+


### PR DESCRIPTION
- introduced makefile
    - added a `build/docs` target that uses `swagger` to parse source code and generate markdown docs inside the `docs/api` dir
- added swagger comments for all api endpoints