### PR TITLE
Return structs, not interfaces

### DIFF
--- a/monitor/exec_monitor.go
+++ b/monitor/exec_monitor.go
@@ -23,7 +23,7 @@ type ExecMonitor struct {
 	FullCmd string
 }
 
-func NewExecMonitor(rmc *RootMonitorConfig) IMonitor {
+func NewExecMonitor(rmc *RootMonitorConfig) *ExecMonitor {
 	e := &ExecMonitor{
 		Base: Base{
 			RMC:        rmc,

--- a/monitor/http_monitor.go
+++ b/monitor/http_monitor.go
@@ -22,7 +22,7 @@ type HTTPMonitor struct {
 	Timeout time.Duration
 }
 
-func NewHTTPMonitor(rmc *RootMonitorConfig) IMonitor {
+func NewHTTPMonitor(rmc *RootMonitorConfig) *HTTPMonitor {
 	h := &HTTPMonitor{
 		Base: Base{
 			RMC:        rmc,

--- a/monitor/http_monitor_test.go
+++ b/monitor/http_monitor_test.go
@@ -43,7 +43,7 @@ var _ = Describe("http_monitor", func() {
 					HTTPStatusCode: 200,
 				},
 			}
-			monitor = NewHTTPMonitor(config).(*HTTPMonitor)
+			monitor = NewHTTPMonitor(config)
 
 			Expect(monitor.Timeout).NotTo(Equal(util.CustomDuration(0)))
 			Expect(monitor.MonitorFunc).NotTo(BeNil())
@@ -61,7 +61,7 @@ var _ = Describe("http_monitor", func() {
 					HTTPStatusCode: 200,
 				},
 			}
-			monitor = NewHTTPMonitor(config).(*HTTPMonitor)
+			monitor = NewHTTPMonitor(config)
 		})
 
 		It("should return nil with correct settings", func() {
@@ -87,7 +87,7 @@ var _ = Describe("http_monitor", func() {
 					HTTPStatusCode: 200,
 				},
 			}
-			monitor = NewHTTPMonitor(config).(*HTTPMonitor)
+			monitor = NewHTTPMonitor(config)
 			url = monitor.constructURL()
 		})
 
@@ -133,7 +133,7 @@ var _ = Describe("http_monitor", func() {
 				Config: &MonitorConfig{},
 			}
 
-			monitor = NewHTTPMonitor(config).(*HTTPMonitor)
+			monitor = NewHTTPMonitor(config)
 		})
 
 		It("handles http URLs", func() {
@@ -180,7 +180,7 @@ var _ = Describe("http_monitor", func() {
 					Host:    "beowulf",
 				},
 			}
-			monitor = NewHTTPMonitor(config).(*HTTPMonitor)
+			monitor = NewHTTPMonitor(config)
 			url = monitor.constructURL()
 		})
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -104,9 +104,9 @@ func New(cfg *config.Config, messageChannel chan *alerter.Message, stateChannel 
 		StateChannel:   stateChannel,
 		MemberID:       cfg.MemberID,
 		SupportedMonitors: map[string]func(*RootMonitorConfig) IMonitor{
-			"http": NewHTTPMonitor,
-			"tcp":  NewTCPMonitor,
-			"exec": NewExecMonitor,
+			"http": func(cfg *RootMonitorConfig) IMonitor { return NewHTTPMonitor(cfg) },
+			"tcp":  func(cfg *RootMonitorConfig) IMonitor { return NewTCPMonitor(cfg) },
+			"exec": func(cfg *RootMonitorConfig) IMonitor { return NewExecMonitor(cfg) },
 		},
 		runningMonitors:    make(map[string]IMonitor, 0),
 		runningMonitorLock: &sync.Mutex{},

--- a/monitor/tcp_monitor.go
+++ b/monitor/tcp_monitor.go
@@ -25,7 +25,7 @@ type TCPMonitor struct {
 	ReadSize     int
 }
 
-func NewTCPMonitor(rmc *RootMonitorConfig) IMonitor {
+func NewTCPMonitor(rmc *RootMonitorConfig) *TCPMonitor {
 	t := &TCPMonitor{
 		Base: Base{
 			RMC:        rmc,


### PR DESCRIPTION
This is the same branch from relistan#1 and just moves the return values of all the `New` functions for the monitors from interfaces to native types. 👍 

@skey