### PR TITLE
Add builds for Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 sudo: false
 go:
   - 1.7.3
+  - 1.8.x
   - tip
 env:
   global:


### PR DESCRIPTION
@skey this will add a build for Go 1.8.x (picks up current latest patch level) without removing the other two builds. I'm seeing drastically shorter build times on 1.8 vs 1.7 for one of my projects.

Also worth considering adding a `deploy` section to the `.travis.yml` that will push to GitHub releases (I didn't do that here). [Here's an example](https://github.com/Nitro/sidecar/blob/master/.travis.yml#L39).