### PR TITLE
do not use kingpin's env var parsing for []string

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -83,6 +84,11 @@ func StringSliceContains(stringSlice []string, data string) bool {
 	}
 
 	return false
+}
+
+func SplitTags(tags string) []string {
+	tags = strings.Replace(tags, " ", "", -1)
+	return strings.Split(tags, ",")
 }
 
 // Return true if ANY element in s1 appears in s2, otherwise return false


### PR DESCRIPTION
- turns out that kingpin's envvar for .Strings() tries to split on newline. This doesn't work great if you are defining the vars via a yaml file, etc.; updated to use our own method -- ie. .Replace and .Split on `,`