### PR TITLE
modify startup flags/envs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - NINEV_ETCD_MEMBERS=http://etcd:2379
       - NINEV_DEBUG=true
-      - NINEV_TAGS=foo
+      - NINEV_MEMBER_TAGS=foo
   9volt3:
     depends_on: 
       - etcd
@@ -34,7 +34,7 @@ services:
     environment:
       - NINEV_ETCD_MEMBERS=http://etcd:2379
       - NINEV_DEBUG=true
-      - NINEV_TAGS=foo, bar
+      - NINEV_MEMBER_TAGS=foo, bar
   etcd:
     image: quay.io/coreos/etcd:v3.1.2
     ports:

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -5,9 +5,9 @@ You can pass several config env vars to `9volt` at startup, which will allow you
 
 | Env Var | Default | Description | Example |
 |---------|---------|-------------|---------|
-| `NINEV_ETCD_MEMBERS` | N/A | Space separated list of etcd member URL's | `export NINEV_ETCD_MEMBERS="http://localhost:2379 http://some.etcd.host.example.com:2379"` |
+| `NINEV_ETCD_MEMBERS` | N/A | Comma separated list of etcd member URL's | `export NINEV_ETCD_MEMBERS="http://localhost:2379,http://some.etcd.host.example.com:2379"` |
 | `NINEV_LISTEN_ADDRESS` | 0.0.0.0:8080 | Listen address that 9volt should bind to | `$ export NINEV_LISTEN_ADDRESS=":8181"` |
 | `NINEV_ETCD_PREFIX` | 9volt | What prefix 9volt should use when reading/writing to/from etcd | `$ export NINEV_ETCD_PREFIX="my-prefix"` |
-| `NINEV_TAGS` | N/A | Space separated list of tags (this can allow you to (re)distribute and assign checks to nodes matching specific tags. See more info [here](MONITOR_CONFIGS.md)) | `$ export NINEV_TAGS="tag1 tag2"` |
+| `NINEV_MEMBER_TAGS` | N/A | Comma separated list of tags (this can allow you to (re)distribute and assign checks to nodes matching specific tags. See more info [here](MONITOR_CONFIGS.md)) | `$ export NINEV_MEMBER_TAGS="tag1,tag2"` |
 
-**NOTE**: Command line params override env vars. Ie. In `export NINEV_TAGS="one two three"; ./9volt -e http://localhost:2379 -t "1 2 3"` - `tags` will be set to `1`, `2` and `3`. Env vars *will* override defaults however.
+**NOTE**: Command line params override env vars. Ie. In `export NINEV_MEMBER_TAGS="one two three"; ./9volt -e http://localhost:2379 -t "1 2 3"` - `tags` will be set to `1`, `2` and `3`. Env vars *will* override defaults however.

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func runServer() {
 
 	// kingpin splits on newline (?); split our tags on ',' instead
 	memberTags := util.SplitTags(*tags)
-	etcdMemberList := strings.Split(*etcdMembers, ",")
+	etcdMemberList := util.SplitTags(*etcdMembers)
 
 	// Create an initial dal client
 	dalClient, err := dal.New(*etcdPrefix, etcdMemberList)
@@ -163,7 +163,7 @@ func runServer() {
 }
 
 func runCfgUtil() {
-	etcdMemberList := strings.Split(*etcdMembers, ",")
+	etcdMemberList := util.SplitTags(*etcdMembers)
 
 	etcdClient, err := dal.NewCfgUtil(etcdMemberList, *etcdPrefix, *replaceFlag, *dryrunFlag, *nosyncFlag)
 	if err != nil {


### PR DESCRIPTION
- `NINEV_TAGS` to become `NINEV_MEMBER_TAGS `
- member tags and etcd hosts are comma separated