### PR TITLE
playing around with some potential ways to handle watcher failures

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ func (c *Config) ValidateDirs() []string {
 		}
 
 		if !exists {
-			if err := c.DalClient.Set(d, "", true, 0, ""); err != nil {
+			if err := c.DalClient.Set(d, "", true, 0, "", false); err != nil {
 				errorList = append(errorList, fmt.Sprintf("unable to auto-create missing dir '%v': %v", d, err))
 				continue
 			}
@@ -94,7 +94,7 @@ func (c *Config) Load() error {
 	}
 
 	if !exists {
-		if err := c.DalClient.Set("config", DEFAULT_CONFIG, false, 0, ""); err != nil {
+		if err := c.DalClient.Set("config", DEFAULT_CONFIG, false, 0, "", false); err != nil {
 			return fmt.Errorf("unable to create initial config: %v", err)
 		}
 

--- a/dal/api_monitor.go
+++ b/dal/api_monitor.go
@@ -29,7 +29,7 @@ func (d *Dal) UpdateCheckState(state bool, checkName string) error {
 	}
 
 	// push updated config to etcd
-	if err := d.Set(fullPath, string(newData), false, 0, ""); err != nil {
+	if err := d.Set(fullPath, string(newData), false, 0, "", false); err != nil {
 		return fmt.Errorf("Unable to update config '%v' in etcd: %v", checkName, err)
 	}
 

--- a/director/director.go
+++ b/director/director.go
@@ -324,7 +324,10 @@ func (d *Director) verifyMemberExistence() error {
 	// Let's wait a `heartbeatInterval`*2 to ensure that at least 1 active member
 	// is in the cluster (if not - there's either a bug or the system is *massively* overloaded)
 	tmpCtx, _ := context.WithTimeout(context.Background(), time.Duration(d.Config.HeartbeatInterval)*2)
-	tmpWatcher := d.DalClient.NewWatcher("cluster/members/", true)
+	tmpWatcher, err := d.DalClient.NewWatcher("cluster/members/", true, true)
+	if err != nil {
+		return fmt.Errorf("Unable to create a new watcher: %v", err)
+	}
 
 	for {
 		resp, err := tmpWatcher.Next(tmpCtx)
@@ -351,7 +354,10 @@ func (d *Director) verifyMemberExistence() error {
 func (d *Director) runCheckConfigWatcher(ctx context.Context) {
 	log.Debugf("%v-checkConfigWatcher: Launching...", d.Identifier)
 
-	watcher := d.DalClient.NewWatcher("monitor/", true)
+	watcher, err := d.DalClient.NewWatcher("monitor/", true, true)
+	if err != nil {
+		log.Fatalf("Unable to start initial monitor/ watcher: %v", err)
+	}
 
 	// TODO: Needs to be turned into a looper
 	for {

--- a/event/event.go
+++ b/event/event.go
@@ -84,7 +84,7 @@ func (q *Queue) runWorker(id int) {
 		// write it to etcd
 		fullKey := fmt.Sprintf("event/%v-%v", e.Type, util.RandomString(6, true))
 
-		if err := q.DalClient.Set(fullKey, string(eventBlob), false, MAX_EVENT_AGE, ""); err != nil {
+		if err := q.DalClient.Set(fullKey, string(eventBlob), false, MAX_EVENT_AGE, "", false); err != nil {
 			log.Errorf("%v: Unable to save event blob '%v' to path '%v' to etcd (worker: #%v): %v",
 				q.Identifier, e, fullKey, id, err)
 		}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -47,7 +47,10 @@ func (m *Manager) Start() error {
 func (m *Manager) run() error {
 	memberConfigDir := fmt.Sprintf("cluster/members/%v/config", m.MemberID)
 
-	watcher := m.Config.DalClient.NewWatcher(memberConfigDir, true)
+	watcher, err := m.Config.DalClient.NewWatcher(memberConfigDir, true, true)
+	if err != nil {
+		log.Fatalf("%v: Unable to start initial member config watcher: %v", m.Identifier, err)
+	}
 
 	m.Looper.Loop(func() error {
 		resp, err := watcher.Next(context.Background())

--- a/state/state.go
+++ b/state/state.go
@@ -102,7 +102,7 @@ func (s *State) runDumper() error {
 				continue
 			}
 
-			if err := s.Config.DalClient.Set(fullKey, string(messageBlob), false, 0, ""); err != nil {
+			if err := s.Config.DalClient.Set(fullKey, string(messageBlob), false, 0, "", false); err != nil {
 				s.Config.EQClient.AddWithErrorLog("error",
 					fmt.Sprintf("%v: Unable to dump state for key %v: %v", s.Identifier, k, err))
 				continue


### PR DESCRIPTION
DO NOT MERGE // Just playing around with some ideas

@jescochu 

This is a quick mess around with a "simpler" approach to handling etcd watcher outages. I think there's a number of edge cases and the whole thing feels .. off.

For giggles, I updated the `*dal.Set()` to have `mkdir -p` behavior. That works as expected. The watcher stuff.. probably works? I didn't look deep enough. See what you think.