### PR TITLE
Dselans/empty alerters

### DIFF
--- a/alerter/alerter.go
+++ b/alerter/alerter.go
@@ -131,6 +131,12 @@ func (a *Alerter) handleMessage(msg *Message) error {
 		return err
 	}
 
+	// Nothing to do if the alerter config is empty
+	if len(msg.Key) == 0 {
+		a.Log.WithField("uuid", msg.uuid).Debug("Not sending any message - alerter not set in config")
+		return nil
+	}
+
 	errorList := make([]string, 0)
 
 	// fetch alert configuration for each individual key, send alert for each.
@@ -201,10 +207,6 @@ func (a *Alerter) loadAlerterConfig(alerterKey string, msg *Message) (*AlerterCo
 
 // Perform message validation; return err if one of required fields is not filled out
 func (a *Alerter) validateMessage(msg *Message) error {
-	if len(msg.Key) == 0 {
-		return errors.New("Message must have at least one element in the 'Key' slice")
-	}
-
 	if msg.Source == "" {
 		return errors.New("Message must have the 'Source' value filled out")
 	}

--- a/docs/example-configs/example1.yaml
+++ b/docs/example-configs/example1.yaml
@@ -319,7 +319,6 @@ monitor:
   #   host: cloudsy.com
   #   timeout: 5s
   #   interval: 10s
-  #   disable: true
   #   expect: OpenSSH
   #   port: 22
   #   tags:
@@ -348,44 +347,4 @@ monitor:
   #   warning-alerter:
   #     - primary-pagerduty
   #   critical-alerter:
-  #     - primary-pagerduty
-
-  # ssh-expect-ssh-check:
-  #   type: tcp
-  #   description: "remote tcp check with expect"
-  #   host: cloudsy.com
-  #   timeout: 5s
-  #   interval: 10s
-  #   disable: true
-  #   expect: OpenSSH
-  #   port: 22
-  #   tags:
-  #     - team-core
-  #     - golang
-  #   warning-threshold: 1
-  #   critical-threshold: 3
-  #   warning-alerter:
-  #     - secondary-slack
-  #   critical-alerter:
-  #     - secondary-slack
-  #     - primary-pagerduty
-
-  # basic-http-check:
-  #   type: http
-  #   description: "basic http status code check"
-  #   host: cloudsy.com
-  #   timeout: 5s
-  #   interval: 10s
-  #   enabled: true
-  #   port: 80
-  #   status-code: 200
-  #   tags:
-  #     - team-core
-  #     - golang
-  #   warning-threshold: 1
-  #   critical-threshold: 3
-  #   warning-alerter:
-  #     - primary-slack
-  #   critical-alerter:
-  #     - primary-slack
   #     - primary-pagerduty

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -89,12 +89,18 @@ func (m *Manager) run() error {
 		}
 
 		if m.ignorableWatcherEvent(resp) {
-			m.Log.Debugf("Received an ignorable watcher '%v' event for key '%v'", resp.Action, resp.Node.Key)
+			m.Log.WithFields(log.Fields{
+				"action": resp.Action,
+				"key":    resp.Node.Key,
+			}).Debug("Received an ignorable watcher event")
 			continue
 		}
 
-		m.Log.Debugf("Received a '%v' watcher event for '%v' (value: '%v')",
-			resp.Action, resp.Node.Key, resp.Node.Value)
+		m.Log.WithFields(log.Fields{
+			"action": resp.Action,
+			"key":    resp.Node.Key,
+			"value":  resp.Node.Value,
+		}).Debug("Received watcher event")
 
 		switch resp.Action {
 		case "set":

--- a/monitor/base_monitor.go
+++ b/monitor/base_monitor.go
@@ -55,7 +55,9 @@ func (b *Base) Identify() string {
 
 // Run the check on a given interval -> evaluate response via b.handle()
 func (b *Base) Run() error {
-	log.Debugf("%v-%v: Starting work for monitor %v...", b.Identify(), b.RMC.GID, b.RMC.Name)
+	llog := b.RMC.Log.WithFields(log.Fields{"monitorName": b.RMC.Name, "method": b.RMC.Name})
+
+	llog.Debug("Starting work")
 
 	defer b.RMC.Ticker.Stop()
 
@@ -65,17 +67,17 @@ Mainloop:
 	for {
 		select {
 		case <-b.RMC.Ticker.C:
-			log.Debugf("%v-%v: Tick for monitor %v", b.Identify(), b.RMC.GID, b.RMC.Name)
+			llog.Debug("Monitor tick")
 			if err := b.handle(b.MonitorFunc()); err != nil {
 				log.Errorf("Unable to complete check handler: %v", err.Error())
 			}
 		case <-b.RMC.StopChannel:
-			log.Debugf("%v-%v: Asked to shutdown monitor %v", b.Identify(), b.RMC.GID, b.RMC.Name)
+			llog.Debug("Asked to shutdown")
 			break Mainloop
 		}
 	}
 
-	log.Debugf("%v-%v: Goroutine has been stopped for monitor %v; exiting...", b.Identify(), b.RMC.GID, b.RMC.Name)
+	llog.Debug("Goroutine exiting...")
 	return nil
 }
 
@@ -133,8 +135,11 @@ func (b *Base) sendMessage(curState int, titleMessage, alertMessage, errorDetail
 	// Send the message
 	b.RMC.MessageChannel <- msg
 
-	log.Debugf("%v-%v: Successfully sent '%v' message for %v (%v)",
-		b.Identifier, b.RMC.GID, msg.Type, b.RMC.ConfigName, b.RMC.Name)
+	b.RMC.Log.WithFields(log.Fields{
+		"configName": b.RMC.ConfigName,
+		"msgType":    msg.Type,
+		"name":       b.RMC.Name,
+	}).Debug("Successfully sent message")
 
 	// Get resolve functions ready
 	for _, alert := range alertKey[curState] {
@@ -182,7 +187,7 @@ func (b *Base) updateState(monitorErr error) error {
 		Config:  jsonConfig,
 	}
 
-	log.Debugf("%v: Successfully sent state message for '%v' to state reader", b.Identifier, b.RMC.ConfigName)
+	b.RMC.Log.WithField("configName", b.RMC.ConfigName).Debug("Successfully sent state message")
 
 	return nil
 }

--- a/monitor/base_monitor.go
+++ b/monitor/base_monitor.go
@@ -111,7 +111,7 @@ func (b *Base) sendMessage(curState int, titleMessage, alertMessage, errorDetail
 	var alertType = [3]string{"resolve", "warning", "critical"}
 	var alertKey = [3][]string{[]string{}, b.RMC.Config.WarningAlerter, b.RMC.Config.CriticalAlerter}
 
-	log.Warningf("%v-%v: (%v) %v", b.Identifier, b.RMC.GID, b.RMC.Name, alertMessage)
+	log.Debugf("%v-%v: (%v) %v", b.Identifier, b.RMC.GID, b.RMC.Name, alertMessage)
 
 	msg := &alerter.Message{
 		Type:        alertType[curState],

--- a/monitor/base_monitor_test.go
+++ b/monitor/base_monitor_test.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"time"
 
-	"github.com/9corp/9volt/alerter"
-	"github.com/9corp/9volt/state"
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/9corp/9volt/alerter"
+	"github.com/9corp/9volt/state"
 )
 
 const (
@@ -40,6 +42,7 @@ var _ = Describe("base_monitor", func() {
 			StopChannel:    stopChan,
 			StateChannel:   stateChan,
 			ConfigName:     "mock_config",
+			Log:            log.New(),
 			MessageChannel: messageChan,
 			Config: &MonitorConfig{
 				CriticalThreshold: CriticalMessages,

--- a/monitor/dns_monitor.go
+++ b/monitor/dns_monitor.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/9corp/9volt/util"
-	log "github.com/Sirupsen/logrus"
 	resolver "github.com/miekg/dns"
+
+	"github.com/9corp/9volt/util"
 )
 
 const (
@@ -60,10 +60,7 @@ func NewDnsMonitor(rmc *RootMonitorConfig) *DnsMonitor {
 }
 
 func (dns *DnsMonitor) Validate() error {
-	log.Debugf(
-		"%v: Performing monitor config validation for %v",
-		dns.Identifier, dns.RMC.ConfigName,
-	)
+	dns.RMC.Log.WithField("configName", dns.RMC.ConfigName).Debug("Performing monitor config validation")
 
 	if _, ok := resolver.StringToType[strings.ToUpper(dns.RMC.Config.DnsRecordType)]; !ok {
 		return fmt.Errorf("Unknown record type: %s", dns.RMC.Config.DnsRecordType)
@@ -104,7 +101,7 @@ func (dns *DnsMonitor) dnsCheck() error {
 	target := resolver.Fqdn(dns.RMC.Config.DnsTarget)
 	server := dns.RMC.Config.Host + ":53" // Only support port 53 at least for now
 
-	log.Debugf("%s: Resolving %s against %s", dns.Identifier, target, server)
+	dns.RMC.Log.Debugf("Resolving %s against %s", target, server)
 
 	msg.SetQuestion(target, qType)
 
@@ -156,9 +153,7 @@ func (dns *DnsMonitor) dnsCheck() error {
 			continue
 		}
 
-		log.Warnf("%s: Found non-matching records in DNS result: '%s'",
-			dns.Identifier, ans.Header().String(),
-		)
+		dns.RMC.Log.Warningf("Found non-matching records in DNS result: '%s'", ans.Header().String())
 	}
 
 	if foundCount == expectedCount {

--- a/monitor/dns_monitor_test.go
+++ b/monitor/dns_monitor_test.go
@@ -3,9 +3,11 @@ package monitor
 import (
 	"time"
 
-	"github.com/9corp/9volt/util"
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/9corp/9volt/util"
 )
 
 var _ = Describe("dns_monitor", func() {
@@ -23,6 +25,7 @@ var _ = Describe("dns_monitor", func() {
 				DnsRecordType: "A",
 				Interval:      util.CustomDuration(3 * time.Second),
 			},
+			Log: log.New(),
 		}
 
 		monitor = NewDnsMonitor(config)

--- a/monitor/exec_monitor.go
+++ b/monitor/exec_monitor.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 const (
@@ -45,7 +43,7 @@ func NewExecMonitor(rmc *RootMonitorConfig) *ExecMonitor {
 }
 
 func (e *ExecMonitor) Validate() error {
-	log.Debugf("%v: Performing monitor config validation for %v", e.Identifier, e.RMC.ConfigName)
+	e.RMC.Log.WithField("configName", e.RMC.ConfigName).Debug("Performing monitor config validation")
 
 	if e.RMC.Config.ExecCommand == "" {
 		return errors.New("'command' cannot be blank")
@@ -59,7 +57,7 @@ func (e *ExecMonitor) Validate() error {
 }
 
 func (e *ExecMonitor) execCheck() error {
-	log.Debugf("%v-%v: Performing check for '%v'", e.Identifier, e.RMC.GID, e.RMC.ConfigName)
+	e.RMC.Log.WithField("configName", e.RMC.ConfigName).Debug("Performing check")
 
 	ctx, cancel := context.WithTimeout(context.Background(), e.Timeout)
 	defer cancel()

--- a/monitor/http_monitor.go
+++ b/monitor/http_monitor.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/9corp/9volt/util"
-	log "github.com/Sirupsen/logrus"
 )
 
 const (
@@ -42,7 +41,7 @@ func NewHTTPMonitor(rmc *RootMonitorConfig) *HTTPMonitor {
 }
 
 func (h *HTTPMonitor) Validate() error {
-	log.Debugf("%v: Performing monitor config validation for %v", h.Identifier, h.RMC.ConfigName)
+	h.RMC.Log.WithField("configName", h.RMC.ConfigName).Debug("Performing monitor config validation")
 
 	if h.Timeout >= time.Duration(h.RMC.Config.Interval) {
 		return fmt.Errorf("'timeout' (%v) cannot equal or exceed 'interval' (%v)", h.Timeout.String(), h.RMC.Config.Interval.String())
@@ -56,7 +55,7 @@ func (h *HTTPMonitor) Validate() error {
 func (h *HTTPMonitor) httpCheck() error {
 	fullURL := h.constructURL()
 
-	log.Debugf("%v-%v: Performing http check for '%v'", h.Identify(), h.RMC.GID, fullURL)
+	h.RMC.Log.WithField("fullURL", fullURL).Debug("Performing http check")
 
 	resp, err := h.performRequest(h.RMC.Config.HTTPMethod, fullURL, h.RMC.Config.HTTPRequestBody)
 	if err != nil {

--- a/monitor/http_monitor_test.go
+++ b/monitor/http_monitor_test.go
@@ -4,10 +4,12 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/9corp/9volt/util"
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/jarcoal/httpmock.v1"
+
+	"github.com/9corp/9volt/util"
 )
 
 var _ = BeforeSuite(func() {
@@ -42,6 +44,7 @@ var _ = Describe("http_monitor", func() {
 					Host:           "beowulf",
 					HTTPStatusCode: 200,
 				},
+				Log: log.New(),
 			}
 			monitor = NewHTTPMonitor(config)
 
@@ -60,6 +63,7 @@ var _ = Describe("http_monitor", func() {
 					Host:           "beowulf",
 					HTTPStatusCode: 200,
 				},
+				Log: log.New(),
 			}
 			monitor = NewHTTPMonitor(config)
 		})
@@ -86,6 +90,7 @@ var _ = Describe("http_monitor", func() {
 					Host:           "beowulf",
 					HTTPStatusCode: 200,
 				},
+				Log: log.New(),
 			}
 			monitor = NewHTTPMonitor(config)
 			url = monitor.constructURL()
@@ -131,6 +136,7 @@ var _ = Describe("http_monitor", func() {
 		BeforeEach(func() {
 			config = &RootMonitorConfig{
 				Config: &MonitorConfig{},
+				Log:    log.New(),
 			}
 
 			monitor = NewHTTPMonitor(config)
@@ -179,6 +185,7 @@ var _ = Describe("http_monitor", func() {
 					HTTPSSL: true,
 					Host:    "beowulf",
 				},
+				Log: log.New(),
 			}
 			monitor = NewHTTPMonitor(config)
 			url = monitor.constructURL()

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -278,23 +278,18 @@ func (m *Monitor) validateMonitorConfig(monitorConfig *MonitorConfig) error {
 		return errors.New("'interval' must be > 0s")
 	}
 
-	if monitorConfig.CriticalThreshold == 0 {
-		return errors.New("'critical-threshold' must be non-zero")
+	if monitorConfig.WarningThreshold < 0 {
+		return errors.New("'critical-threshold' must be larger or equal to 0")
+	}
+
+	if monitorConfig.CriticalThreshold < 0 {
+		return errors.New("'critical-threshold' must be larger or equal to 0")
 	}
 
 	// TODO: Logic for this should be changed/fixed at some point
+	// edit1: Should it? seems to make sense right now ~dselans 04.27.2017
 	if monitorConfig.WarningThreshold > monitorConfig.CriticalThreshold {
 		return errors.New("'warning-threshold' cannot be larger than 'CriticalThreshold'")
-	}
-
-	// TODO: It should be possible to NOT have a WarningAlerter setting (and just
-	// have a `CriticalAlerter` setting)
-	if len(monitorConfig.WarningAlerter) == 0 {
-		return errors.New("'warning-alerter' list must contain at least one entry")
-	}
-
-	if len(monitorConfig.CriticalAlerter) == 0 {
-		return errors.New("'critical-alerter' list must contain at least one entry")
 	}
 
 	if monitorConfig.Port > MAX_PORT {

--- a/monitor/sample_monitor.go
+++ b/monitor/sample_monitor.go
@@ -12,10 +12,6 @@
 
 package monitor
 
-import (
-	log "github.com/Sirupsen/logrus"
-)
-
 type SampleMonitor struct {
 	Base
 }
@@ -38,7 +34,7 @@ func (s *SampleMonitor) Validate() error {
 }
 
 func (s *SampleMonitor) sampleCheck() error {
-	log.Debugf("%v-%v: Performing check for '%v'", s.Identifier, s.RMC.GID, s.RMC.ConfigName)
+	s.RMC.Log.WithField("configName", s.RMC.ConfigName).Debug("Performing sample check")
 
 	return nil
 }

--- a/monitor/tcp_monitor.go
+++ b/monitor/tcp_monitor.go
@@ -41,7 +41,7 @@ func NewTCPMonitor(rmc *RootMonitorConfig) *TCPMonitor {
 }
 
 func (t *TCPMonitor) Validate() error {
-	log.Debugf("%v: Performing monitor config validation for %v", t.Identifier, t.RMC.ConfigName)
+	t.RMC.Log.WithField("configName", t.RMC.ConfigName).Debug("Performing monitor config validation")
 
 	if t.ConnTimeout >= time.Duration(t.RMC.Config.Interval) {
 		return fmt.Errorf("'timeout' (%v) cannot equal or exceed 'interval' (%v)", t.ConnTimeout.String(), t.RMC.Config.Interval.String())
@@ -99,7 +99,7 @@ func (t *TCPMonitor) updateSettings() {
 func (t *TCPMonitor) tcpCheck() error {
 	fullAddress := fmt.Sprintf("%v:%v", t.RMC.Config.Host, t.RMC.Config.Port)
 
-	log.Debugf("%v-%v: Performing tcp check against '%v'", t.Identify(), t.RMC.GID, fullAddress)
+	t.RMC.Log.WithField("address", fullAddress).Debug("Performing tcp check")
 
 	// Open the connection
 	conn, err := net.DialTimeout("tcp", fullAddress, t.ConnTimeout)

--- a/overwatch/overwatch_test.go
+++ b/overwatch/overwatch_test.go
@@ -5,10 +5,9 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
-	// . "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
 	d "github.com/relistan/go-director"
 
 	"github.com/9corp/9volt/base"
@@ -51,6 +50,7 @@ var _ = Describe("overwatch", func() {
 			Components:   components,
 			WatchLooper:  watchLooper,
 			Looper:       listenerLooper,
+			Log:          log.New(),
 			Component: base.Component{
 				Identifier: "overwatch",
 			},


### PR DESCRIPTION
This PR combines two things:

- allowing alerters to not be set
- cleaning up logs across most of the project (ie. making logs a bit more uniform)

The 2nd part should've been in a separate PR, but what started as just a one or two line change, ended up going across the entire project. Woops.

This addresses #149 